### PR TITLE
example of enabling email notification for GloBI integrity check - re…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ install:
   - chmod +x check-dataset.sh
 
 script: ./check-dataset.sh ${TRAVIS_REPO_SLUG}
+
+notifications:
+  email:
+    - jhpoelen+avian@gmail.com
+    - jhpoelen+avian2@gmail.com


### PR DESCRIPTION
…lated to https://github.com/hurlbertlab/dietdatabase/issues/95

By default travis only sends email notifications to person responsible for a "broken" build. However, there's a way to configure notifications, including email notifications to change this default behavior. 
Please see https://docs.travis-ci.com/user/notifications/#Configuring-email-notifications for more information on default behavior.